### PR TITLE
Add code to pom.xml files to run tests from maven

### DIFF
--- a/async-jaxrs-application/gradle.properties
+++ b/async-jaxrs-application/gradle.properties
@@ -2,4 +2,4 @@
 # -------------
 # Update this to point to a liberty server install
 # This is needed to find the dependencies to build the code and to run the tests
-libertyRoot=C:/install/wlp/8556/GM/wlp
+libertyRoot=

--- a/async-jaxrs-application/pom.xml
+++ b/async-jaxrs-application/pom.xml
@@ -55,6 +55,21 @@
                 <artifactId>javax.ejb-api</artifactId>
                 <version>3.2</version>
             </dependency>
+            <dependency>
+            	<groupId>junit</groupId>
+            	<artifactId>junit</artifactId>
+            	<version>4.12</version>
+            </dependency>
+            <dependency>
+		       	<groupId>org.apache.cxf</groupId>
+		       	<artifactId>cxf-rt-rs-client</artifactId>
+		       	<version>3.1.1</version>
+        	</dependency>
+        	<dependency>
+		       	<groupId>org.glassfish</groupId>
+		       	<artifactId>javax.json</artifactId>
+		       	<version>1.0.4</version>
+        	</dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -84,9 +99,35 @@
             <artifactId>javax.ejb-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+       	    <groupId>junit</groupId>
+           	<artifactId>junit</artifactId>
+           	<scope>test</scope>
+        </dependency>
+        <dependency>
+        	<groupId>org.apache.cxf</groupId>
+        	<artifactId>cxf-rt-rs-client</artifactId>
+        	<scope>test</scope>
+        </dependency>
+        <dependency>
+        	<groupId>org.glassfish</groupId>
+        	<artifactId>javax.json</artifactId>
+        	<scope>test</scope>
+        </dependency>
     </dependencies>
+    
+    <properties>
+    	<!-- Update this to point to a liberty server install
+        This is needed to find the dependencies to build the code and to run the tests -->
+		<install.directory><!-- Set this --></install.directory>
+		<!-- Update this to match the port number in the JaxrsSample server.xml
+		This is needed to run the tests -->
+		<liberty.test.port.property>9081</liberty.test.port.property>
+	</properties>
 
     <build>
+	    <testSourceDirectory>${basedir}/src/fvt/java</testSourceDirectory>
+	    <testOutputDirectory>${project.build.directory}/fvt</testOutputDirectory>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -95,6 +136,105 @@
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>../async-jaxrs-wlpcfg/servers/jaxrsSample/apps</outputDirectory>
+                            <stripVersion>true</stripVersion>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>net.wasdev.wlp.sample</groupId>
+                                    <artifactId>async-jaxrs-application</artifactId>
+                                    <version>1.0-SNAPSHOT</version>
+                                    <type>war</type>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+            	<groupId>net.wasdev.wlp.maven.plugins</groupId>
+            	<artifactId>liberty-maven-plugin</artifactId>
+            	<version>1.0</version>
+            	<executions>
+            		<execution>
+            			<id>start-server</id>
+            			<phase>pre-integration-test</phase>
+            			<goals>
+            				<goal>start-server</goal>
+            			</goals>
+            			<configuration>
+            				<configFiles>${basedir}/../async-jaxrs-wlpcfg/servers/jaxrsSample/server.xml</configFiles>
+            			</configuration>
+            		</execution>
+            		<execution>
+            			<id>stop-server</id>
+            			<phase>post-integration-test</phase>
+            			<goals>
+            				<goal>stop-server</goal>
+            			</goals>
+            		</execution>
+            	</executions>
+            	<configuration>
+       				<installDirectory>${install.directory}</installDirectory>
+       				<serverName>jaxrsSample</serverName>
+       				<userDirectory>${basedir}/../async-jaxrs-wlpcfg</userDirectory>
+            	</configuration>
+            </plugin>
+            <plugin>
+            	<groupId>org.apache.maven.plugins</groupId>
+            	<artifactId>maven-failsafe-plugin</artifactId>
+            	<version>2.18.1</version>
+            	<executions>
+            		<execution>
+            			<phase>integration-test</phase>
+            			<id>integration-test</id>
+            			<goals>
+            				<goal>integration-test</goal>
+            				<goal>verify</goal>
+            			</goals>
+            			<configuration>
+            				<testSourceDirectory>${basedir}/src/fvt/java</testSourceDirectory>
+            				<testClassesDirectory>${project.build.directory}/fvt</testClassesDirectory>
+            			</configuration>
+            		</execution>
+            	</executions>
+            </plugin>
+            <plugin>
+            	<groupId>org.apache.maven.plugins</groupId>
+            	<artifactId>maven-surefire-plugin</artifactId>
+            	<version>2.18.1</version>
+            	<executions>
+            		<execution>
+            			<phase>test</phase>
+            			<id>default-test</id>
+            			<configuration>
+            				<skipTests>true</skipTests>
+            			</configuration>
+            		</execution>
+            		<execution>
+            			<phase>integration-test</phase>
+            			<id>integration-test</id>
+            			<goals>
+            				<goal>test</goal>
+            			</goals>
+           				<configuration>
+		       				<systemPropertyVariables>
+		   						<liberty.test.port>${liberty.test.port.property}</liberty.test.port>
+		      				</systemPropertyVariables>
+           				</configuration>
+            		</execution>
+            	</executions>
             </plugin>
         </plugins>
     </build>

--- a/async-jaxrs-wlpcfg/pom.xml
+++ b/async-jaxrs-wlpcfg/pom.xml
@@ -38,32 +38,6 @@
                     </filesets>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.6</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>../async-jaxrs-wlpcfg/servers/jaxrsSample/apps</outputDirectory>
-                            <silent>true</silent>
-                            <stripVersion>true</stripVersion>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>net.wasdev.wlp.sample</groupId>
-                                    <artifactId>async-jaxrs-application</artifactId>
-                                    <version>1.0-SNAPSHOT</version>
-                                    <type>war</type>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Add code to pom.xml files to run tests. Move copy task across to application pom.xml so it runs before the tests. Update
gradle.properties file to have a blank libertyRoot.
